### PR TITLE
Update deploy workflow to include subdirectory navigation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,5 +26,6 @@ jobs:
           cd ${{ secrets.APP_DIR }}
           git pull origin main
           source .venv/bin/activate
+          cd enki-media
           pip install -r requirements.txt
           EOF


### PR DESCRIPTION
Added a step to navigate into the `enki-media` directory before installing dependencies. This ensures the correct path is used for the application setup during deployment.