### PR TITLE
Enhance file download headers with UTF-8 filename support

### DIFF
--- a/storage/views.py
+++ b/storage/views.py
@@ -1,22 +1,29 @@
 from django.http import HttpResponse, Http404
 from django.views.generic.detail import DetailView
 from .models import UploadedFile
-
+from urllib.parse import quote
 
 class PublicFileView(DetailView):
     model = UploadedFile
     context_object_name = "uploaded_file"
 
     def get(self, request, *args, **kwargs):
-        # Try to fetch the object; raises Http404 if not found or not public
         obj = self.get_object()
 
         if not obj.is_public:
             raise Http404("This file is not public.")
 
-        # Opens the file for download
-        response = HttpResponse(obj.stored_file.open("rb"), content_type="application/octet-stream")
+        file = obj.stored_file
+        file_name = file.name.split("/")[-1]
 
-        # Sets the HTTP headers for file download
-        response["Content-Disposition"] = f'attachment; filename="{obj.stored_file.name.split("/")[-1]}"'
+        response = HttpResponse(file.open("rb"), content_type="application/octet-stream")
+
+        # Fallback filename (ASCII only), and UTF-8 encoded filename
+        ascii_filename = file_name.encode("ascii", "ignore").decode()
+        utf8_filename = quote(file_name)
+
+        response["Content-Disposition"] = (
+            f'attachment; filename="{ascii_filename}"; filename*=UTF-8\'\'{utf8_filename}'
+        )
+
         return response


### PR DESCRIPTION
Updated the `Content-Disposition` header to include both an ASCII fallback filename and a UTF-8 encoded filename. This ensures proper handling of non-ASCII characters in file names across various browsers.